### PR TITLE
Add 'Get Involved'

### DIFF
--- a/content/get-involved.md
+++ b/content/get-involved.md
@@ -13,6 +13,10 @@ We think [MDN Web Docs](https://developer.mozilla.org/) is the best web docs sit
 
 - If you see an issue on MDN that you know how to fix, please [make a pull request](https://github.com/mdn/content/pulls). The [mdn/content README](https://github.com/mdn/content) has instructions for contributing to the repo, and we're always happy to provide guidance for contributors.
 
+## Attend an event
+
+We host and attend writing events such as the [Writing Day at the Write the Docs Prague conference in 2021](https://www.writethedocs.org/conf/prague/2021/writing-day/). We come with a list of projects for people to work on, or you can bring your own, and we will help people to get started. [Follow us on Twitter](https://twitter.com/OpenWebDocs) to learn about events we'll be at!
+
 ## Donate to Open Web Docs
 
 You can support our work by making a donation through [Open Collective](https://opencollective.com/open-web-docs/).

--- a/content/get-involved.md
+++ b/content/get-involved.md
@@ -1,0 +1,18 @@
+---
+title: "Get Involved"
+url: "/get-involved"
+summary: How to get involved with Open Web Docs
+---
+If you're interesting in helping to ensure that the Web has high-quality accessible documentation, available to everyone, here are some of the  ways you can help us out.
+
+## Contribute to MDN Web Docs
+
+We think [MDN Web Docs](https://developer.mozilla.org/) is the best web docs site out there, and we spend most of our time maintaining and extending it, mostly through contributions to the [mdn/content](https://github.com/mdn/content) repo.
+
+- If you find a problem on MDN, please [file an issue](https://github.com/mdn/content/issues).
+
+- If you see an issue on MDN that you know how to fix, please [make a pull request](https://github.com/mdn/content/pulls). The [mdn/content README](https://github.com/mdn/content) has instructions for contributing to the repo, and we're always happy to provide guidance for contributors.
+
+## Donate to Open Web Docs
+
+You can support our work by making a donation through [Open Collective](https://opencollective.com/open-web-docs/).

--- a/content/get-involved.md
+++ b/content/get-involved.md
@@ -9,13 +9,15 @@ If you're interested in helping to ensure that the Web has high-quality accessib
 
 We think [MDN Web Docs](https://developer.mozilla.org/) is the best web docs site out there, and we spend most of our time maintaining and extending it, mostly through contributions to the [mdn/content](https://github.com/mdn/content) repo.
 
-- If you find a problem on MDN, please [file an issue](https://github.com/mdn/content/issues).
+If you'd like to help out with this work, a great place to start is by fixing issues in mdn/content. The [mdn/content README](https://github.com/mdn/content) has instructions for contributing to the repo.
 
-- If you see an issue on MDN that you know how to fix, please [make a pull request](https://github.com/mdn/content/pulls). The [mdn/content README](https://github.com/mdn/content) has instructions for contributing to the repo, and we're always happy to provide guidance for contributors.
+Have a look at the [issue backlog](https://github.com/mdn/content/issues). Issues include typos, errors, things that are not clear, as well as requests for new documentation. If you're getting started, have a look at the issues labeled [good first issue](https://github.com/mdn/content/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22), but you don't have to restrict yourself to this list. If you want to take an issue, ask us to assign it to you. Please feel free to ask for help — we're always happy to provide guidance for contributors.
+
+If you'd like to propose a bigger change, we track potential Open Web Docs projects as issues in the [openwebdocs/project](https://github.com/openwebdocs/project/issues) repository. Please file an issue there and we'll consider it in our project planning. If you'd like to help out with a proposal we have already listed, comment on the issue. We'd love to talk to you about it.
 
 ## Attend an event
 
-We host and attend writing events such as the [Writing Day at the Write the Docs Prague conference in 2021](https://www.writethedocs.org/conf/prague/2021/writing-day/). We come with a list of projects for people to work on, or you can bring your own, and we will help people to get started. [Follow us on Twitter](https://twitter.com/OpenWebDocs) to learn about events we'll be at!
+We host and attend writing events such as the Writing Day at the [Write the Docs Prague conference in 2021](https://www.writethedocs.org/conf/prague/2021/writing-day/). We come with a list of projects for you to work on, or you can bring your own, and we will help you get started. [Follow us on Twitter](https://twitter.com/OpenWebDocs) to learn about events we'll be at!
 
 ## Donate to Open Web Docs
 


### PR DESCRIPTION
Fixes https://github.com/openwebdocs/website/issues/9.

I'm not very good at these types of pages so I'd welcome some input. I did consider having a bit on "Make a project proposal" but I feel like we should have more meta-docs for this before we can do that (describing, for example, what makes a good proposal, and how we assess them, etc).

Also ping @robnyman for any possible improvements (since IIRC he asked for this :).