### PR TITLE
Use system theme for light/dark mode

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -39,3 +39,5 @@ params:
           url: "https://github.com/openwebdocs"
         - name: twitter
           url: "https://twitter.com/OpenWebDocs"
+    defaultTheme: auto
+    disableThemeToggle: true


### PR DESCRIPTION
This is related to https://github.com/openwebdocs/website/issues/19 and in particular the comment "ideally, something that gets picked automatically via browser setting".

[It looks as if we can configure the PaperMod theme to use the OS setting for light/dark](https://adityatelange.github.io/hugo-PaperMod/posts/papermod/papermod-features/#default-theme-lightdarkauto), based on the [`prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) media feature.

So this PR is intended to do that, removing the toggle and just using the OS preference.

I guess this also helps with not having to ask people about cookie preferences?

I have tested this and while it seems to work fine in Chrome it doesn't seem to work in Firefox: that is, when I change my system theme I don't see the change reflected in the site in Firefox. But it does work [using the devtools to simulate a theme change](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/examine_and_edit_css/index.html#view-media-rules-for-prefers-color-scheme).

What do you think?

(If you don't like this approach it would be easy enough to move the toggle, instead.)